### PR TITLE
configure: Do not rely on implicit declaration for detecting daemon

### DIFF
--- a/configure
+++ b/configure
@@ -6802,6 +6802,7 @@ else
 
 echo '
 #include <stdlib.h>
+#include <unistd.h>
 ' >conftest.c
 echo 'void f(){ (void)daemon(0, 0); }' >>conftest.c
 if test -z "`$CC -c conftest.c 2>&1 | grep deprecated`"; then

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,7 @@ AC_CHECK_FUNCS([daemon])
 if test $ac_cv_func_daemon = yes; then
         ACX_FUNC_DEPRECATED([daemon], [(void)daemon(0, 0);], [
 #include <stdlib.h>
+#include <unistd.h>
 ])
 fi
 


### PR DESCRIPTION
On GNU/Linux, the daemon function is declared in <unistd.h>, not <stdlib.h>.  Add the additional #include directive to prepare for compilers which do not accept implicit function declarations by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC

